### PR TITLE
Add HTML entity replacements for tab and space characters

### DIFF
--- a/csharp/DiffMatchPatch.cs
+++ b/csharp/DiffMatchPatch.cs
@@ -1338,7 +1338,7 @@ namespace DiffMatchPatch {
       StringBuilder html = new StringBuilder();
       foreach (Diff aDiff in diffs) {
         string text = aDiff.text.Replace("&", "&amp;").Replace("<", "&lt;")
-          .Replace(">", "&gt;").Replace("\n", "&para;<br>");
+          .Replace(">", "&gt;").Replace("\n", "&para;<br>").Replace("\t", "&emsp;").Replace(" ", "&nbsp;");
         switch (aDiff.operation) {
           case Operation.INSERT:
             html.Append("<ins style=\"background:#e6ffe6;\">").Append(text)


### PR DESCRIPTION
`diff_prettyHtml` currently doesn't highlight leading/trailing space differences. Because spaces in HTML aren't visible.

This pull request changes that.

Instead of

```html
<ins style="background:#e6ffe6;"> </ins>
```

`diff_prettyHtml` now returns

```html
<ins style="background:#e6ffe6;">&nbsp;</ins>
```

resulting in differences with leading/training spaces being visible in HTML.

Example:
When we compare "Test" and "Test " (notice the second string doesn't equal the first string since it has a trailing space).

```javascript
var diff = dmp.diff_main("Test", "Test "); // this results in the following diff: [[0, 'Test'], [1, ' ']]
```

Previously looked like this:

![242906142-5ebd2764-0129-49f0-b3c0-ec77319316f3](https://github.com/dmsnell/diff-match-patch/assets/112876534/bbd523e3-f2d2-49f6-b5db-219c552ce0f1)


Now with this pull requests it looks like this:

![242906167-f99add6a-79c2-42f5-8286-fa043903b9f5](https://github.com/dmsnell/diff-match-patch/assets/112876534/3cee9d34-9750-456c-bb01-7299054d1e29)

Note: this issue also seems to be present in the JavaScript implementation: https://github.com/google/diff-match-patch/pull/144


