### PR TITLE
Add CI for JS

### DIFF
--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -1,0 +1,32 @@
+name: javascript
+
+on:
+  push:
+    paths:
+      - .github/workflows/javascript.yml
+      - javascript/**
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/javascript.yml
+      - javascript/**
+
+defaults:
+  run:
+    working-directory: javascript
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      ## Cache not needed because we have no dependencies.
+      ## If we need it, here's how
+      #          cache: npm
+      #          cache-dependency-path: 'javascript/package-lock.json'
+      - run: npm test

--- a/javascript/readme.md
+++ b/javascript/readme.md
@@ -1,0 +1,3 @@
+The Diff Match and Patch libraries offer robust algorithms to perform the operations required for synchronizing plain text.
+
+This is the JavaScript implementation of a library available in many languages, for more information and API documentation please refer to the [project readme](https://github.com/dmsnell/diff-match-patch).


### PR DESCRIPTION
The build is constrained to the 'javascript' folder so it won't run for changes to other languages.

I also included a simple readme for the NPM package, the top-level readme is probably a bit much to include there.